### PR TITLE
Print in logger the request's uuid

### DIFF
--- a/src/kemalyst/handler/logger.cr
+++ b/src/kemalyst/handler/logger.cr
@@ -1,7 +1,7 @@
 module Kemalyst::Handler
   # The Logger handler logs every request/response to the provided logger.
   # The logger can be configured as STDIN/STDOUT or as a log file.  A custom
-  # logger can be configured and passed in as well. 
+  # logger can be configured and passed in as well.
   class Logger < Base
     property logger : ::Logger
 
@@ -21,7 +21,8 @@ module Kemalyst::Handler
       resource = context.request.resource
       elapsed = elapsed_text(Time.now - time)
 
-      output_message = "#{status_code} | #{method} #{resource} | #{elapsed}"
+      output_message = "#{context.request.uuid} #{status_code} | #{method} #{resource} | #{elapsed}"
+
       @logger.info output_message
       context
     end

--- a/src/kemalyst/request.cr
+++ b/src/kemalyst/request.cr
@@ -1,0 +1,9 @@
+require "secure_random"
+
+class HTTP::Request
+  property uuid
+
+  def uuid
+    @uuid ||= SecureRandom.uuid
+  end
+end


### PR DESCRIPTION
When debugging a web application and reading its logs, it is useful an unique identifier to be able to keep track of the problematic request. To accomplish that I have done the following:
- Reopen Request class to add a new property 'uuid', which marks the
  request with an unique identifier
- Print the new uuid property of the request in the application logger
