### PR TITLE
Fix postinstall issue with Crystal 0.20.0

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -20,7 +20,3 @@ shards:
     github: jeromegn/kilt
     version: 0.3.3
 
-  pool:
-    github: ysbaddaden/pool
-    version: 0.2.3
-

--- a/shard.yml
+++ b/shard.yml
@@ -9,7 +9,7 @@ license: MIT
 dependencies:
   kemalyst-model:
     github: drujensen/kemalyst-model
-    version: 0.2.3
+    version: 0.2.4
 
   kemalyst-validators:
     github: drujensen/kemalyst-validators
@@ -18,10 +18,10 @@ dependencies:
   delimiter_tree:
     github: drujensen/delimiter_tree
     version: 0.1.0
-    
+
   kilt:
     github: jeromegn/kilt
     version: 0.3.3
 
 scripts:
-  postinstall: crystal templates/install.cr 
+  postinstall: crystal src/templates/install.cr


### PR DESCRIPTION
`src/` needed to be added before the path.

Previously, `shards update` would fail with this error:
```
Postinstall crystal templates/install.cr
Failed crystal templates/install.cr:
Error: unknown command: templates/install.cr
```