### PR TITLE
HTTP::Handler is now a module instead of a class

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drujensen/crystal:0.20.1
+FROM drujensen/crystal:0.20.3
 
 ADD . /app/user
 WORKDIR /app/user

--- a/src/kemalyst/controller.cr
+++ b/src/kemalyst/controller.cr
@@ -3,7 +3,8 @@ require "kilt"
 
 # The base controller provides a singleton pattern for the HTTP::Handler and
 # some macros that provide syntax sugar for rendering a response.
-class Kemalyst::Controller < HTTP::Handler
+class Kemalyst::Controller
+  include HTTP::Handler
 
   # class method to return a singleton instance of this Controller
   def self.instance

--- a/src/kemalyst/handler/base.cr
+++ b/src/kemalyst/handler/base.cr
@@ -4,7 +4,8 @@ module Kemalyst::Handler
   # The base class for Kemalyst handlers.  This extension provides a singleton
   # method and ability to configure each handler.  All configurations should
   # be maintained in the `/config` folder for consistency.
-  class Base < HTTP::Handler
+  class Base
+    include HTTP::Handler
 
     # class method to return a singleton instance of this Controller
     def self.instance

--- a/src/kemalyst/handler/block.cr
+++ b/src/kemalyst/handler/block.cr
@@ -2,7 +2,8 @@ module Kemalyst::Handler
   # This handler is a wrapper around a block.  This is used to allow a route
   # to be configured with only a block but still provides the call_next
   # method so this block can be chained in the callstack.
-  class Block < HTTP::Handler
+  class Block
+    include HTTP::Handler
 
     # class method to return a singleton instance of this Controller
     def self.instance

--- a/src/kemalyst/websocket.cr
+++ b/src/kemalyst/websocket.cr
@@ -38,7 +38,8 @@ require "openssl/sha1"
 # HTTP::WebSocket.  Notice that the  WebSocket handler `call_next` if the
 # headers do not request for an upgrade.  It passes through the request to the
 # next handler in the chain.
-class Kemalyst::WebSocket < HTTP::Handler
+class Kemalyst::WebSocket
+  include HTTP::Handler
 
   # class method to return a singleton instance of this Controller
   def self.instance


### PR DESCRIPTION
Update for change in Crystal v 0.20.3 - HTTP::Handler is now a module instead of a class