### PR TITLE
made params available on action to save time.

### DIFF
--- a/src/kemalyst/controller.cr
+++ b/src/kemalyst/controller.cr
@@ -82,6 +82,7 @@ module ActionHelper
   macro action(name, &content)
     class {{name.id.camelcase}} < Kemalyst::Controller
       def call(context)
+        params = context.params
         {{content.body}}
       end
     end


### PR DESCRIPTION
It think it would be useful to be able to directly access params instead of context params inside of action. This will also look more familiar to rails when I demo it at railsconf.