### PR TITLE
allow chaining after controller

### DIFF
--- a/spec/kemalyst/handler/logger_spec.cr
+++ b/spec/kemalyst/handler/logger_spec.cr
@@ -6,7 +6,7 @@ describe Kemalyst::Handler::Logger do
     io, context = create_context(request)
 
     router = Kemalyst::Handler::Router.new
-    handler = Kemalyst::Handler::Block.new(->(c : HTTP::Server::Context) { "Hello World!" })
+    handler = Kemalyst::Handler::Block.new(->(context : HTTP::Server::Context) { context.response.print "Hello World!" })
     router.add_route("GET", "/", handler)
 
     loghandler = Kemalyst::Handler::Logger.instance

--- a/spec/kemalyst/handler/logger_spec.cr
+++ b/spec/kemalyst/handler/logger_spec.cr
@@ -6,7 +6,7 @@ describe Kemalyst::Handler::Logger do
     io, context = create_context(request)
 
     router = Kemalyst::Handler::Router.new
-    handler = Kemalyst::Handler::Block.new(->(context : HTTP::Server::Context) { context.response.print "Hello World!" })
+    handler = Kemalyst::Handler::Block.new(->(c : HTTP::Server::Context) { "Hello World!" })
     router.add_route("GET", "/", handler)
 
     loghandler = Kemalyst::Handler::Logger.instance

--- a/spec/kemalyst/handler/router_spec.cr
+++ b/spec/kemalyst/handler/router_spec.cr
@@ -23,7 +23,7 @@ describe Kemalyst::Handler::Router do
     io, context = create_context(request)
 
     router = Kemalyst::Handler::Router.new
-    handler = Kemalyst::Handler::Block.new(->(c : HTTP::Server::Context) { "Hello World!" })
+    handler = Kemalyst::Handler::Block.new(->(context : HTTP::Server::Context) { context.response.print "Hello World!" })
     router.add_route("GET", "/", handler)
     router.call(context)
     context.response.headers["content_type"].should eq "text/html"
@@ -31,7 +31,7 @@ describe Kemalyst::Handler::Router do
 
   it "set response body to Hello World!" do
     router = Kemalyst::Handler::Router.new
-    handler = Kemalyst::Handler::Block.new(->(c : HTTP::Server::Context) { "Hello World!" })
+    handler = Kemalyst::Handler::Block.new(->(context : HTTP::Server::Context) { context.response.print "Hello World!" })
     router.add_route("GET", "/", handler)
 
     request = HTTP::Request.new("GET", "/")
@@ -45,7 +45,7 @@ describe Kemalyst::Handler::Router do
 
   it "builds handler callstack for routes individually in order" do
     router = Kemalyst::Handler::Router.new
-    handler = Kemalyst::Handler::Block.new(->(c : HTTP::Server::Context) { "Hello World!" })
+    handler = Kemalyst::Handler::Block.new(->(context : HTTP::Server::Context) { context.response.print "Hello World!" })
     socket = Kemalyst::WebSocket.new
     router.add_route("GET", "/", socket)
     router.add_route("GET", "/", handler)
@@ -57,7 +57,7 @@ describe Kemalyst::Handler::Router do
   it "process_request and clean state" do
     router = Kemalyst::Handler::Router.new
     handler0 = TestHandler.new
-    handler1 = Kemalyst::Handler::Block.new(->(c : HTTP::Server::Context) { "Dashboard" })
+    handler1 = Kemalyst::Handler::Block.new(->(context : HTTP::Server::Context) { context.response.print "Dashboard" })
 
     router.add_route("GET", "/*", handler0)
     router.add_route("GET", "/dashboard", handler1)

--- a/spec/kemalyst/handler/router_spec.cr
+++ b/spec/kemalyst/handler/router_spec.cr
@@ -23,7 +23,7 @@ describe Kemalyst::Handler::Router do
     io, context = create_context(request)
 
     router = Kemalyst::Handler::Router.new
-    handler = Kemalyst::Handler::Block.new(->(context : HTTP::Server::Context) { context.response.print "Hello World!" })
+    handler = Kemalyst::Handler::Block.new(->(context : HTTP::Server::Context) { "Hello World!" })
     router.add_route("GET", "/", handler)
     router.call(context)
     context.response.headers["content_type"].should eq "text/html"
@@ -31,7 +31,7 @@ describe Kemalyst::Handler::Router do
 
   it "set response body to Hello World!" do
     router = Kemalyst::Handler::Router.new
-    handler = Kemalyst::Handler::Block.new(->(context : HTTP::Server::Context) { context.response.print "Hello World!" })
+    handler = Kemalyst::Handler::Block.new(->(context : HTTP::Server::Context) { "Hello World!" })
     router.add_route("GET", "/", handler)
 
     request = HTTP::Request.new("GET", "/")
@@ -45,7 +45,7 @@ describe Kemalyst::Handler::Router do
 
   it "builds handler callstack for routes individually in order" do
     router = Kemalyst::Handler::Router.new
-    handler = Kemalyst::Handler::Block.new(->(context : HTTP::Server::Context) { context.response.print "Hello World!" })
+    handler = Kemalyst::Handler::Block.new(->(context : HTTP::Server::Context) { "Hello World!" })
     socket = Kemalyst::WebSocket.new
     router.add_route("GET", "/", socket)
     router.add_route("GET", "/", handler)
@@ -57,7 +57,7 @@ describe Kemalyst::Handler::Router do
   it "process_request and clean state" do
     router = Kemalyst::Handler::Router.new
     handler0 = TestHandler.new
-    handler1 = Kemalyst::Handler::Block.new(->(context : HTTP::Server::Context) { context.response.print "Dashboard" })
+    handler1 = Kemalyst::Handler::Block.new(->(context : HTTP::Server::Context) { "Dashboard" })
 
     router.add_route("GET", "/*", handler0)
     router.add_route("GET", "/dashboard", handler1)

--- a/spec/kemalyst/handler/spec_helper.cr
+++ b/spec/kemalyst/handler/spec_helper.cr
@@ -5,7 +5,7 @@ class TestHandler < Kemalyst::Handler::Base
     if self.next != nil
       call_next context
     else
-      "All"
+      context.response.print "All"
     end
   end
 end

--- a/spec/kemalyst/websocket_spec.cr
+++ b/spec/kemalyst/websocket_spec.cr
@@ -10,7 +10,7 @@ describe Kemalyst::WebSocket do
     request = HTTP::Request.new("GET", "/", headers)
     io, context = create_context(request)
     websocket = Kemalyst::WebSocket.new
-    handler = Kemalyst::Handler::Block.new(->(c : HTTP::Server::Context) { "Hello World!" })
+    handler = Kemalyst::Handler::Block.new(->(context : HTTP::Server::Context) { context.response.print "Hello World!" })
     router = Kemalyst::Handler::Router.new
     router.add_route("GET", "/", websocket)
     router.add_route("GET", "/", handler)

--- a/spec/kemalyst/websocket_spec.cr
+++ b/spec/kemalyst/websocket_spec.cr
@@ -10,7 +10,7 @@ describe Kemalyst::WebSocket do
     request = HTTP::Request.new("GET", "/", headers)
     io, context = create_context(request)
     websocket = Kemalyst::WebSocket.new
-    handler = Kemalyst::Handler::Block.new(->(context : HTTP::Server::Context) { context.response.print "Hello World!" })
+    handler = Kemalyst::Handler::Block.new(->(context : HTTP::Server::Context) { "Hello World!" })
     router = Kemalyst::Handler::Router.new
     router.add_route("GET", "/", websocket)
     router.add_route("GET", "/", handler)

--- a/src/kemalyst/controller.cr
+++ b/src/kemalyst/controller.cr
@@ -13,10 +13,8 @@ class Kemalyst::Controller
   end
 
   # Call is the execution method for this controller.  Controllers can be
-  # chained together and should `call_next(context)` if they do not provide
-  # the final rendering of the response.  If they are the last leaf in the
-  # chain, then they should return a String that will be printed to the
-  # response io.
+  # chained together and should `call_next(context)` if they do not provide 
+  # the final rendering of the response.
   def call(context)
     call_next context
   end
@@ -38,14 +36,16 @@ class Kemalyst::Controller
 
   # helper to render a view with a layout.  The view name is relative to `src/views`
   # directory and the layout is relative to `src/views/layouts` directory.
-  macro render(filename, layout)
-    content = render("{{filename.id}}")
-    render("layouts/{{layout.id}}")
+  macro render(filename, layout, *args)
+    content = Kilt.render("src/views/{{filename.id}}", {{*args}})
+    content_with_layout = Kilt.render("src/views/layouts/{{layout.id}}")
+    context.response.print(content_with_layout)
   end
 
   # helper to render a template.  The view name is relative to `src/views` directory.
   macro render(filename, *args)
-    Kilt.render("src/views/{{filename.id}}", {{*args}})
+    content = Kilt.render("src/views/{{filename.id}}", {{*args}})
+    context.response.print(content)
   end
 
   # helper to redirect to another page.  This sets the Location header to
@@ -53,28 +53,27 @@ class Kemalyst::Controller
   macro redirect(url, status_code = 302)
     context.response.headers.add("Location", {{url}})
     context.response.status_code = {{status_code}}
-    return ""
   end
 
   # helper to render text.  This sets the content_type to `plain/text`
   macro text(body, status_code = 200)
     context.response.status_code = {{status_code}}
     context.response.content_type = "text/plain"
-    return {{body}}
+    context.response.print({{body}})
   end
 
   # helper to render html.  This sets the content_type to `text/html`
   macro html(body, status_code = 200)
     context.response.status_code = {{status_code}}
     context.response.content_type = "text/html"
-    return {{body}}
+    context.response.print({{body}})
   end
 
   # helper to render json.  This sets the content_type to `application/json`
   macro json(body, status_code = 200)
     context.response.status_code = {{status_code}}
     context.response.content_type = "application/json"
-    return {{body}}
+    context.response.print({{body}})
   end
 end
 

--- a/src/kemalyst/handler/block.cr
+++ b/src/kemalyst/handler/block.cr
@@ -2,15 +2,13 @@ module Kemalyst::Handler
   # This handler is a wrapper around a block.  This is used to allow a route
   # to be configured with only a block but still provides the call_next
   # method so this block can be chained in the callstack.
-  class Block
-    include HTTP::Handler
-
+  class Block < Base
     # class method to return a singleton instance of this Controller
     def self.instance
       @@instance ||= new
     end
 
-    def initialize(@block : (HTTP::Server::Context -> String))
+    def initialize(@block : (HTTP::Server::Context -> Nil))
     end
 
     def call(context)

--- a/src/kemalyst/handler/block.cr
+++ b/src/kemalyst/handler/block.cr
@@ -8,11 +8,12 @@ module Kemalyst::Handler
       @@instance ||= new
     end
 
-    def initialize(@block : (HTTP::Server::Context -> Nil))
+    def initialize(@block : (HTTP::Server::Context -> String))
     end
 
     def call(context)
       content = @block.call(context)
+      context.response.print content
     end
   end
 end

--- a/src/kemalyst/handler/router.cr
+++ b/src/kemalyst/handler/router.cr
@@ -35,15 +35,27 @@ module Kemalyst::Handler
     delete path, handler
   end
 
-  # The resource macro will create a RESTful resource set of routes using a standard naming convention.
-  macro resource(name)
+  # The resources macro will create a set of routes for a list of resources endpoint.
+  macro resources(name)
     get "/{{name.id.downcase}}s", {{name.id.capitalize}}Controller::Index
     get "/{{name.id.downcase}}s/new", {{name.id.capitalize}}Controller::New
     post "/{{name.id.downcase}}s", {{name.id.capitalize}}Controller::Create
     get "/{{name.id.downcase}}s/:id", {{name.id.capitalize}}Controller::Show
     get "/{{name.id.downcase}}s/:id/edit", {{name.id.capitalize}}Controller::Edit
+    patch "/{{name.id.downcase}}s/:id", {{name.id.capitalize}}Controller::Update
     put "/{{name.id.downcase}}s/:id", {{name.id.capitalize}}Controller::Update
     delete "/{{name.id.downcase}}s/:id", {{name.id.capitalize}}Controller::Delete
+  end
+
+  # The resource macro will create a set of routes for a single resource endpoint
+  macro resource(name)
+    get "/{{name.id.downcase}}/new", {{name.id.capitalize}}Controller::New
+    post "/{{name.id.downcase}}", {{name.id.capitalize}}Controller::Create
+    get "/{{name.id.downcase}}", {{name.id.capitalize}}Controller::Show
+    get "/{{name.id.downcase}}/edit", {{name.id.capitalize}}Controller::Edit
+    patch "/{{name.id.downcase}}", {{name.id.capitalize}}Controller::Update
+    put "/{{name.id.downcase}}", {{name.id.capitalize}}Controller::Update
+    delete "/{{name.id.downcase}}", {{name.id.capitalize}}Controller::Delete
   end
 
   # The Route holds the information for the node in the tree.
@@ -163,9 +175,7 @@ module Kemalyst::Handler
           end
 
           if route = routes.first
-            if content = route.handler.call(context).as(String)
-              context.response.print(content)
-            end
+            route.handler.call(context)
           end
 
           # clean state


### PR DESCRIPTION
Change the logic so that you can Chain controllers together.  This will
provide capabilities that were restricted with a final leaf being
required to return a String and the router performing the
response.print.