### PR TITLE
Simplify routes and controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,14 +129,24 @@ settings.  You will find the `database.yml` and `routes.cr` here.
 The router will perform a lookup based on the method and path and return the
 chain of handlers you specify in the `/config/routes.cr` file.
 
-You can use any of the following methods: `get, post, put, patch, delete, all`
+You can use any of these simplified macros: `get, post, patch, delete`
 
-An example of a route would be:
 ```crystal
-get "/",   DemoController::Index
+get "/", home, index
+```
+
+You can specify the class directly:
+```crystal
+get "/",   HomeController::Index
 ```
 You can use `:variable` in the path and it will set a
 context.params["variable"] to the value in the url.
+
+```crystal
+get    "/posts/:id", demo, show
+```
+
+or using the class:
 
 ```crystal
 get    "/posts/:id", DemoController::Show
@@ -150,13 +160,13 @@ get "/", [ BasicAuth.instance("username", "password"),
 or add them individually in the correct order:
 ```crystal
 get "/", BasicAuth.instance("username", "password")
-get "/", DemoController::Index.instance
+get "/", home, index
 ```
 
 This is how you would configure a WebSocket Controller:
 ```crystal
-get "/", ChatController::Chat
-get "/", ChatController::Index
+get "/", chat, socket
+get "/", chat, index
 ```
 See below for more information on how to create a WebSocket Handler.
 
@@ -173,10 +183,8 @@ An example of a controller:
 ```crystal
 require "../models/post"
 
-module Post
-  include ActionHelper #adds in helper method "action"
-
-  action Index do
+class PostController < Kemalyst::Controller
+  action index do
     posts = Post.all("ORDER BY created_at DESC")
     html render("post/index.ecr", "main.ecr")
   end
@@ -187,14 +195,14 @@ Note: The above is shorthand for this:
 ```crystal
 require "../models/post"
 
-class Index < Kemalyst::Controller
+class PostController::Index < Kemalyst::Controller
   def call(context)
     posts = Post.all("ORDER BY created_at DESC")
     html render("post/index.ecr", "main.ecr")
   end
 end
 ```
-There are several helper macros that will set the content type and responses status.
+There are several helper macros that will set the content type and responses status:
 ```crystal
   redirect "path"                       # redirect to path
   html     "<html></html>", 200         # content type `text/html` with status code of 200
@@ -213,8 +221,8 @@ You can use the rendering engine to generate `html`, `json`, `xml` or `text`:
 ```crystal
 require "../models/post"
 
-class Index < Kemalyst::Controller
-  def call(context)
+class HomeController < Kemalyst::Controller
+  action index do
     posts = Post.all("ORDER BY created_at DESC")
     json render("post/index.json.ecr")
   end

--- a/shard.lock
+++ b/shard.lock
@@ -1,28 +1,8 @@
 version: 1.0
 shards:
-  db:
-    github: crystal-lang/crystal-db
-    version: 0.4.2
-
   expect:
     github: dukex/expect.cr
     commit: 17c31a0f42815cd914a630852bb2ee0da6a39dc0
-
-  kemal:
-    github: kemalcr/kemal
-    commit: ce9e924d00d07bf9ca7184a41bc81579da0122ec
-
-  kemalyst-model:
-    github: drujensen/kemalyst-model
-    version: 0.5.11
-
-  kemalyst-spec:
-    github: drujensen/kemalyst-spec
-    version: 0.1.1
-
-  kemalyst-validators:
-    github: drujensen/kemalyst-validators
-    version: 0.2.0
 
   kilt:
     github: jeromegn/kilt
@@ -41,7 +21,7 @@ shards:
     version: 1.8.0
 
   sidekiq:
-    github: drujensen/sidekiq-cli.cr
+    github: kemalyst/sidekiq-cli.cr
     commit: 199757a164daa9fd9d7fe7b334eed2af8ec8c26c
 
   slang:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: kemalyst
-version: 0.7.1
+version: 0.8.0
 
 authors:
   - drujensen <drujensen@gmail.com>
@@ -7,22 +7,14 @@ authors:
 license: MIT
 
 dependencies:
-  kemal:
-    github: kemalcr/kemal
-    branch: master  
-  
-  kemalyst-model:
-    github: drujensen/kemalyst-model
-    version: ~> 0.5.0
+  kilt:
+    github: jeromegn/kilt
+    version: 0.3.3
 
-  kemalyst-validators:
-    github: drujensen/kemalyst-validators
-    version: ~> 0.2.0
-
-  kemalyst-spec:
-    github: drujensen/kemalyst-spec
-    version: ~> 0.1.0
-
+  radix:
+    github: luislavena/radix
+    version: 0.3.8
+    
   slang:
     github: jeromegn/slang
     branch: master
@@ -32,7 +24,7 @@ dependencies:
     branch: master
 
   sidekiq:
-    github: drujensen/sidekiq-cli.cr
+    github: kemalyst/sidekiq-cli.cr
     branch: master
 
 development_dependencies:

--- a/spec/kemalyst/controller_spec.cr
+++ b/spec/kemalyst/controller_spec.cr
@@ -1,9 +1,5 @@
 require "./spec_helper"
 
-ActionHelper.action TestShow do
-  "Hello World!"
-end
-
 describe Kemalyst::Controller do
   it "provides csrf token" do
     request = HTTP::Request.new("GET", "/")
@@ -19,12 +15,5 @@ describe Kemalyst::Controller do
     context.session["csrf.token"] = "test"
     controller = Kemalyst::Controller.instance
     expect(controller.csrf_tag(context)).to eq "<input type=\"hidden\" name=\"_csrf\" value=\"test\" />"
-  end
-
-  it "should create controller action with action helper" do
-    request = HTTP::Request.new("GET", "/")
-    io, context = create_context(request)
-
-    expect(TestShow.instance.call(context)).to eq "Hello World!"
   end
 end

--- a/src/kemalyst/controller.cr
+++ b/src/kemalyst/controller.cr
@@ -34,6 +34,16 @@ class Kemalyst::Controller
     Kemalyst::Handler::CSRF.instance.tag(context)
   end
 
+  # action helper to simplify the controllers
+  macro action(name, &content)
+    class {{name.id.camelcase}} < Kemalyst::Controller
+      def call(context)
+        params = context.params
+        {{content.body}}
+      end
+    end
+  end
+
   # helper to render a view with a layout.  The view name is relative to `src/views`
   # directory and the layout is relative to `src/views/layouts` directory.
   macro render(filename, layout, *args)
@@ -79,16 +89,5 @@ class Kemalyst::Controller
     context.response.status_code = {{status_code}}
     context.response.content_type = "application/xml"
     context.response.print({{body}})
-  end
-end
-
-module ActionHelper
-  macro action(name, &content)
-    class {{name.id.camelcase}} < Kemalyst::Controller
-      def call(context)
-        params = context.params
-        {{content.body}}
-      end
-    end
   end
 end

--- a/src/kemalyst/handler/router.cr
+++ b/src/kemalyst/handler/router.cr
@@ -6,23 +6,23 @@ module Kemalyst::Handler
 
   {% for method in HTTP_METHODS %}
     def {{method.id}}(path, &block : HTTP::Server::Context -> _)
-      handler = Kemalyst::Handler::Block.new(block)
-      Kemalyst::Handler::Router.instance.add_route({{method}}.upcase, path, handler)
+      handler = Block.new(block)
+      Router.instance.add_route({{method}}.upcase, path, handler)
     end
     def {{method.id}}(path, handler : HTTP::Handler)
-      Kemalyst::Handler::Router.instance.add_route({{method}}.upcase, path, handler)
+      Router.instance.add_route({{method}}.upcase, path, handler)
     end
     def {{method.id}}(path, handler : HTTP::Handler.class)
-      Kemalyst::Handler::Router.instance.add_route({{method}}.upcase, path, handler.instance)
+      Router.instance.add_route({{method}}.upcase, path, handler.instance)
     end
     def {{method.id}}(path, handlers : Array(HTTP::Handler))
       handlers.each do |handler|
-        Kemalyst::Handler::Router.instance.add_route({{method}}.upcase, path, handler)
+        Router.instance.add_route({{method}}.upcase, path, handler)
       end
     end
     def {{method.id}}(path, handlers : Array(HTTP::Handler.class))
       handlers.each do |handler|
-        Kemalyst::Handler::Router.instance.add_route({{method}}.upcase, path, handler.instance)
+        Router.instance.add_route({{method}}.upcase, path, handler.instance)
       end
     end
   {% end %}
@@ -35,27 +35,41 @@ module Kemalyst::Handler
     delete path, handler
   end
 
+  macro get(path, controller, action)
+    Router.instance.add_route "get", "{{path.id}}", {{controller.id.capitalize}}Controller::{{action.id.capitalize}}.instance
+  end
+
+  macro post(path, controller, action)
+    Router.instance.add_route "post", "{{path.id}}", {{controller.id.capitalize}}Controller::{{action.id.capitalize}}.instance
+  end
+
+  macro patch(path, controller, action)
+    Router.instance.add_route "patch", "{{path.id}}", {{controller.id.capitalize}}Controller::{{action.id.capitalize}}.instance
+  end
+
+  macro delete(path, controller, action)
+    Router.instance.add_route "delete", "{{path.id}}", {{controller.id.capitalize}}Controller::{{action.id.capitalize}}.instance
+  end
+
   # The resources macro will create a set of routes for a list of resources endpoint.
   macro resources(name)
-    get "/{{name.id.downcase}}s", {{name.id.capitalize}}Controller::Index
-    get "/{{name.id.downcase}}s/new", {{name.id.capitalize}}Controller::New
-    post "/{{name.id.downcase}}s", {{name.id.capitalize}}Controller::Create
-    get "/{{name.id.downcase}}s/:id", {{name.id.capitalize}}Controller::Show
-    get "/{{name.id.downcase}}s/:id/edit", {{name.id.capitalize}}Controller::Edit
-    patch "/{{name.id.downcase}}s/:id", {{name.id.capitalize}}Controller::Update
-    put "/{{name.id.downcase}}s/:id", {{name.id.capitalize}}Controller::Update
-    delete "/{{name.id.downcase}}s/:id", {{name.id.capitalize}}Controller::Delete
+    Router.instance.add_route "get", "/{{name.id.downcase}}s", {{name.id.capitalize}}Controller::Index.instance
+    Router.instance.add_route "get", "/{{name.id.downcase}}s/new", {{name.id.capitalize}}Controller::New.instance
+    Router.instance.add_route "post", "/{{name.id.downcase}}s", {{name.id.capitalize}}Controller::Create.instance
+    Router.instance.add_route "get", "/{{name.id.downcase}}s/:id", {{name.id.capitalize}}Controller::Show.instance
+    Router.instance.add_route "get", "/{{name.id.downcase}}s/:id/edit", {{name.id.capitalize}}Controller::Edit.instance
+    Router.instance.add_route "patch", "/{{name.id.downcase}}s/:id", {{name.id.capitalize}}Controller::Update.instance
+    Router.instance.add_route "delete", "/{{name.id.downcase}}s/:id", {{name.id.capitalize}}Controller::Delete.instance
   end
 
   # The resource macro will create a set of routes for a single resource endpoint
   macro resource(name)
-    get "/{{name.id.downcase}}/new", {{name.id.capitalize}}Controller::New
-    post "/{{name.id.downcase}}", {{name.id.capitalize}}Controller::Create
-    get "/{{name.id.downcase}}", {{name.id.capitalize}}Controller::Show
-    get "/{{name.id.downcase}}/edit", {{name.id.capitalize}}Controller::Edit
-    patch "/{{name.id.downcase}}", {{name.id.capitalize}}Controller::Update
-    put "/{{name.id.downcase}}", {{name.id.capitalize}}Controller::Update
-    delete "/{{name.id.downcase}}", {{name.id.capitalize}}Controller::Delete
+    Router.instance.add_route "get", "/{{name.id.downcase}}/new", {{name.id.capitalize}}Controller::New.instance
+    Router.instance.add_route "post", "/{{name.id.downcase}}", {{name.id.capitalize}}Controller::Create.instance
+    Router.instance.add_route "get", "/{{name.id.downcase}}", {{name.id.capitalize}}Controller::Show.instance
+    Router.instance.add_route "get", "/{{name.id.downcase}}/edit", {{name.id.capitalize}}Controller::Edit.instance
+    Router.instance.add_route "patch", "/{{name.id.downcase}}s/:id", {{name.id.capitalize}}Controller::Update.instance
+    Router.instance.add_route "delete", "/{{name.id.downcase}}", {{name.id.capitalize}}Controller::Delete.instance
   end
 
   # The Route holds the information for the node in the tree.

--- a/src/kemalyst/version.cr
+++ b/src/kemalyst/version.cr
@@ -1,0 +1,3 @@
+module Kemalyst
+  VERSION = "0.8.0"
+end


### PR DESCRIPTION
This simplifies the controllers and routes.

breaking change.  This removes the `ActionHelper` module in favor of including the macro directly in the KemalystController.